### PR TITLE
feat: Add surcharges to functions

### DIFF
--- a/src/util/addTaxesToGroup.js
+++ b/src/util/addTaxesToGroup.js
@@ -10,6 +10,7 @@ import xformOrderGroupToCommonOrder from "./xformOrderGroupToCommonOrder.js";
  * @param {Number} discountTotal Calculated discount total
  * @param {Object} group The fulfillment group to be mutated
  * @param {String} orderId ID of existing or new order to which this group will belong
+ * @param {Object} surcharges Surcharges object so it can be passed along
  * @returns {Object} An object with `taxTotal` and `taxableAmount` numeric properties
  */
 export default async function addTaxesToGroup(context, {
@@ -19,7 +20,8 @@ export default async function addTaxesToGroup(context, {
   currencyCode,
   discountTotal,
   group,
-  orderId
+  orderId,
+  surcharges
 }) {
   const { collections, mutations } = context;
 
@@ -31,7 +33,8 @@ export default async function addTaxesToGroup(context, {
     currencyCode,
     group,
     orderId,
-    discountTotal
+    discountTotal,
+    surcharges
   });
 
   // A taxes plugin is expected to add a mutation named `setTaxesOnOrderFulfillmentGroup`.

--- a/src/util/updateGroupTotals.js
+++ b/src/util/updateGroupTotals.js
@@ -65,7 +65,8 @@ export default async function updateGroupTotals(context, {
     currencyCode,
     discountTotal,
     group,
-    orderId
+    orderId,
+    surcharges: groupSurcharges
   });
 
   // Build and set the group invoice

--- a/src/util/xformOrderGroupToCommonOrder.js
+++ b/src/util/xformOrderGroupToCommonOrder.js
@@ -1,12 +1,15 @@
 import accounting from "accounting-js";
 
 /**
+ * @param {String} accountId Account Id
  * @param {Object} [billingAddress] Billing address, if one was collected
  * @param {String} [cartId] The source cart ID, if applicable
  * @param {Object} collections Map of MongoDB collections
  * @param {String} currencyCode The currency code
  * @param {Object} group The order fulfillment group
  * @param {String} orderId The order ID
+ * @param {Number} discountTotal Discount Total
+ * @param {Array} surcharges An array of Surcharges
  * @returns {Object} Valid CommonOrder for the given order group
  */
 export default async function xformOrderGroupToCommonOrder({
@@ -17,7 +20,9 @@ export default async function xformOrderGroupToCommonOrder({
   currencyCode,
   group,
   orderId,
-  discountTotal
+  discountTotal,
+  surcharges = []
+
 }) {
   // ** If you add any data here, be sure to add the same data to the matching xformCartGroupToCommonOrder xform
   const items = group.items.map((item) => ({
@@ -116,6 +121,7 @@ export default async function xformOrderGroupToCommonOrder({
     shippingAddress: address || null,
     shopId,
     sourceType: "order",
-    totals
+    totals,
+    surcharges
   };
 }


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue
Surcharges are not available to many functions to be used in tax or order calculations. Also fixed some missing @/params 

## Solution
Add them as both parameters and return values

## Breaking changes
None


## Testing
Should have no change on existing functions
