### PR TITLE
(feat) Pass cartItem to `mutateNewOrderItemBeforeCreate`

### DIFF
--- a/src/mutations/placeOrder.js
+++ b/src/mutations/placeOrder.js
@@ -175,7 +175,8 @@ export default async function placeOrder(context, input) {
       currencyCode,
       discountTotal,
       inputGroup,
-      orderId
+      orderId,
+      cart
     });
 
     // We save off the first shipping address found, for passing to payment services. They use this

--- a/src/util/buildOrderFulfillmentGroupFromInput.js
+++ b/src/util/buildOrderFulfillmentGroupFromInput.js
@@ -25,7 +25,8 @@ export default async function buildOrderFulfillmentGroupFromInput(context, {
   currencyCode,
   discountTotal,
   inputGroup,
-  orderId
+  orderId,
+  cart
 }) {
   const { data, items, selectedFulfillmentMethodId, shopId, totalPrice: expectedGroupTotal, type } = inputGroup;
 

--- a/src/util/buildOrderFulfillmentGroupFromInput.js
+++ b/src/util/buildOrderFulfillmentGroupFromInput.js
@@ -14,6 +14,7 @@ import updateGroupTotals from "./updateGroupTotals.js";
  * @param {Number} discountTotal Calculated discount total
  * @param {Object} inputGroup Order fulfillment group input. See schema.
  * @param {String} orderId ID of existing or new order to which this group will belong
+ * @param {Object} cart - the cart this order is being created from
  * @returns {Promise<Object>} The fulfillment group
  */
 export default async function buildOrderFulfillmentGroupFromInput(context, {
@@ -39,7 +40,7 @@ export default async function buildOrderFulfillmentGroupFromInput(context, {
   // Build the final order item objects. As part of this, we look up the variant in the system and make sure that
   // the price is what the caller expects it to be.
   if (items) {
-    group.items = await Promise.all(items.map((inputItem) => buildOrderItem(context, { currencyCode, inputItem })));
+    group.items = await Promise.all(items.map((inputItem) => buildOrderItem(context, { currencyCode, inputItem, cart })));
   } else {
     group.items = [];
   }

--- a/src/util/buildOrderItem.js
+++ b/src/util/buildOrderItem.js
@@ -7,9 +7,10 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @param {Object} context an object containing the per-request state
  * @param {String} currencyCode The order currency code
  * @param {Object} inputItem Order item input. See schema.
+ * @param {Object} cart - The cart this order is being built from
  * @returns {Promise<Object>} An order item, matching the schema needed for insertion in the Orders collection
  */
-export default async function buildOrderItem(context, { currencyCode, inputItem }) {
+export default async function buildOrderItem(context, { currencyCode, inputItem, cart }) {
   const { queries } = context;
   const {
     addedAt,
@@ -90,8 +91,9 @@ export default async function buildOrderItem(context, { currencyCode, inputItem 
     workflow: { status: "new", workflow: ["coreOrderWorkflow/created", "coreItemWorkflow/removedFromInventoryAvailableToSell"] }
   };
 
+  const cartItem = cart.items.find((cItem) => cItem.productId === newItem.productId);
   for (const func of context.getFunctionsOfType("mutateNewOrderItemBeforeCreate")) {
-    await func(context, { chosenProduct, chosenVariant, item: newItem }); // eslint-disable-line no-await-in-loop
+    await func(context, { chosenProduct, chosenVariant, item: newItem, cartItem }); // eslint-disable-line no-await-in-loop
   }
 
   return newItem;

--- a/src/util/buildOrderItem.js
+++ b/src/util/buildOrderItem.js
@@ -91,7 +91,10 @@ export default async function buildOrderItem(context, { currencyCode, inputItem,
     workflow: { status: "new", workflow: ["coreOrderWorkflow/created", "coreItemWorkflow/removedFromInventoryAvailableToSell"] }
   };
 
-  const cartItem = cart.items.find((cItem) => cItem.productId === newItem.productId);
+  let cartItem;
+  if (cart && cart.items.length) {
+    cartItem = cart.items.find((cItem) => cItem.productId === newItem.productId);
+  }
   for (const func of context.getFunctionsOfType("mutateNewOrderItemBeforeCreate")) {
     await func(context, { chosenProduct, chosenVariant, item: newItem, cartItem }); // eslint-disable-line no-await-in-loop
   }


### PR DESCRIPTION
Resolves NaN
Impact: **minor**
Type: **feature**

## Issue
There currently is no simple, extensible way to persist cart item custom fields to the order

## Solution
Pass cart down the chain of functions for building the cart till we finally pass is to `mutateNewOrderItemBeforeCreate`. This allows developers to use any cart item data into the order item. There probably should be a corresponding change at the order level but I don't see a hook for a custom function there and this isn't currently functionality we need

## Breaking changes
This should have no impact on the current code if you don't add `mutateNewOrderItemBeforeCreate` functions


## Testing
1. App should work as it does currently

