### PR TITLE
fix: add full name from payments to order

### DIFF
--- a/src/resolvers/Order/billingName.js
+++ b/src/resolvers/Order/billingName.js
@@ -1,0 +1,19 @@
+/**
+ * @name Order/billingName
+ * @method
+ * @memberof Order/GraphQL
+ * @summary Returns a string of comma separated full names involved with payment
+ * @param {Object} context An object with request-specific state
+ * @param {Object} order - Result of the parent resolver, which is a Order object in GraphQL schema format
+ * @returns {String} A string of names
+ */
+
+export default async function billingName (order){
+    if(!Array.isArray(order.payments)) return null
+    let name = "";
+    order.payments.forEach(payment => {
+        name = name.concat(payment.address.fullName + ", ")
+    })
+    //remove the last comma and whitespace
+    return name.replace(/,\s*$/, "") 
+}

--- a/src/resolvers/Order/billingName.js
+++ b/src/resolvers/Order/billingName.js
@@ -3,17 +3,15 @@
  * @method
  * @memberof Order/GraphQL
  * @summary Returns a string of comma separated full names involved with payment
- * @param {Object} context An object with request-specific state
  * @param {Object} order - Result of the parent resolver, which is a Order object in GraphQL schema format
  * @returns {String} A string of names
  */
-
-export default async function billingName (order){
-    if(!Array.isArray(order.payments)) return null
-    let name = "";
-    order.payments.forEach(payment => {
-        name = name.concat(payment.address.fullName + ", ")
-    })
-    //remove the last comma and whitespace
-    return name.replace(/,\s*$/, "") 
+export default async function billingName(order) {
+  if (!Array.isArray(order.payments)) return null;
+  let name = "";
+  order.payments.forEach((payment) => {
+    name = name.concat(`${payment.address.fullName}, `);
+  });
+  // remove the last comma and whitespace
+  return name.replace(/,\s*$/, "");
 }

--- a/src/resolvers/Order/index.js
+++ b/src/resolvers/Order/index.js
@@ -6,10 +6,12 @@ import orderSummary from "./orderSummary.js";
 import payments from "./payments.js";
 import refunds from "./refunds.js";
 import totalItemQuantity from "./totalItemQuantity.js";
+import billingName from "./billingName.js";
 
 export default {
   _id: (node) => encodeOrderOpaqueId(node._id),
   account: resolveAccountFromAccountId,
+  billingName: (node) => billingName(node),
   cartId: (node) => encodeCartOpaqueId(node._id),
   displayStatus: (node, { language }, context) => orderDisplayStatus(context, node, language),
   fulfillmentGroups: (node) => node.shipping || [],

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -542,6 +542,9 @@ type Order implements Node {
   "The account that placed the order. Some orders are created for anonymous users. Anonymous orders have a null account."
   account: Account
 
+  "Full name(s) involved with payment. Payment can be made by one or more than one person"
+  billingName: String
+
   "The ID of the cart that created this order. Carts are deleted after becoming orders, so this is just a reference."
   cartId: ID
 


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves [#22](https://github.com/reactioncommerce/api-plugin-orders/issues/22#issue-787067640)
Impact: **minor**
Type: **bug**

## Issue
For an order, the account properties are hidden for some permission groups. Make some properties like full name and email available at order level for those who do not have permission.

## Solution
The full name of the orderer is taken from the billing information and made available at the order level. Email property was already available at order level. 

## Breaking changes
None


## Testing
In GQL playground try the below query
```
query {
  orders(shopIds:["<shopId>"]){
    nodes{
      email
      billingName
  }
  }
}
```
An order with multiple orderers will return a comma separated string of names
![image](https://user-images.githubusercontent.com/75854210/105524990-0a2d4e80-5ca6-11eb-9f18-1b39287555a3.png)
