### PR TITLE
feat: added the ip of the client who placed an order

### DIFF
--- a/src/mutations/placeOrder.js
+++ b/src/mutations/placeOrder.js
@@ -119,6 +119,7 @@ export default async function placeOrder(context, input) {
   const {
     billingAddress,
     cartId,
+    clientIp,
     currencyCode,
     customFields: customFieldsFromClient,
     email,
@@ -215,6 +216,7 @@ export default async function placeOrder(context, input) {
     accountId,
     billingAddress,
     cartId,
+    clientIp,
     createdAt: now,
     currencyCode,
     discounts,

--- a/src/mutations/placeOrder.test.js
+++ b/src/mutations/placeOrder.test.js
@@ -57,6 +57,7 @@ test("places an anonymous $0 order with no cartId and no payments", async () => 
   const orderInput = Factory.orderInputSchema.makeOne({
     billingAddress: null,
     cartId: null,
+    clientIp: "0.0.0.0",
     currencyCode: "USD",
     email: "valid@email.address",
     ordererPreferredLanguage: "en",
@@ -84,6 +85,7 @@ test("places an anonymous $0 order with no cartId and no payments", async () => 
     ],
     billingAddress: null,
     cartId: null,
+    clientIp: "0.0.0.0",
     createdAt: jasmine.any(Date),
     currencyCode: orderInput.currencyCode,
     customFields: {},

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -551,6 +551,9 @@ type Order implements Node {
   "The date and time at which the cart was created, which is when the first item was added to it."
   createdAt: DateTime!
 
+  "IP address of the client device, which placed the order. Can be used for fraud detection."
+  clientIp: String
+
   "The order status for display in UI"
   displayStatus(
     """
@@ -726,6 +729,9 @@ input OrderInput {
   created.
   """
   cartId: String
+
+  "IP address of the client device, which placed the order. This field is optional and can be used for fraud detection"
+  clientIp: String
 
   "The code for the currency in which all values are being provided"
   currencyCode: String!

--- a/src/simpleSchemas.js
+++ b/src/simpleSchemas.js
@@ -410,6 +410,10 @@ export const orderInputSchema = new SimpleSchema({
     type: String,
     optional: true
   },
+  "clientIp": {
+    type: String,
+    optional: true
+  },
   "currencyCode": String,
   /**
    * If you need to store customFields, be sure to add them to your
@@ -997,6 +1001,7 @@ export const Payment = new SimpleSchema({
  * @property {Date} anonymousAccessTokens.createdAt When the token was created. Expiry is not currently implemented, but this Date is here to support that.
  * @property {Address} [billingAddress] Optional billing address
  * @property {String} cartId optional For tracking which cart created this order
+ * @property {String} clientIp optional IP of the device of the client, who placed the order
  * @property {Date} createdAt required
  * @property {String} currencyCode required
  * @property {Object} customFields optional
@@ -1039,6 +1044,10 @@ export const Order = new SimpleSchema({
     optional: true
   },
   "createdAt": Date,
+  "clientIp": {
+    type: String,
+    optional: true
+  },
   "currencyCode": String,
   "customFields": {
     type: Object,


### PR DESCRIPTION
Signed-off-by: tedraykov <tedraykov@gmail.com>

Resolves #11
Impact: **minor**
Type: **feature**

## Issue
Many payment providers require the IP of the client, who is placing an order, for fraud detection. The current orders schema doesn't have such property.

## Solution
Added the `clientIp` property to the orders schema. The new property is optional and will be persisted in the database if it is provided in the `placeOrder` mutation

## Testing
1. Unit test for placing orders updated to validate the new property is correctly persisted
