### PR TITLE
fix: order item imageURLs

### DIFF
--- a/src/util/imageURLs.js
+++ b/src/util/imageURLs.js
@@ -1,0 +1,54 @@
+/**
+ * @method ensureAbsoluteUrls
+ * @summary ensure cart imageInfo URLs are absolute
+ * @param {Object} imageInfo - input ImageInfo
+ * @param {Object} context - The per request context
+ * @returns {Object} infoImage object
+ */
+function ensureAbsoluteUrls(imageInfo, context) {
+  const absoluteImagePaths = {};
+
+  Object.keys(imageInfo).forEach((name) => {
+    absoluteImagePaths[name] = context.getAbsoluteUrl(imageInfo[name]);
+  });
+
+  return absoluteImagePaths;
+}
+
+/**
+ *
+ * @method imageURLs
+ * @summary Get primary image urls for order item
+ * @param {Object} context - The per-request context
+ * @param {Object} item -  A order item
+ * @returns {Object} ImageSizes object
+ */
+export default async function imageURLs(context, item) {
+  const { Media } = context.collections;
+  const { productId, variantId } = item;
+  if (!Media) return {};
+
+  const media = await Media.find({
+    "$or": [
+      { "metadata.productId": productId },
+      { "metadata.variantId": variantId }
+    ],
+    "metadata.workflow": { $nin: ["archived", "unpublished"] }
+  }, {
+    sort: { "metadata.priority": 1, "uploadedAt": 1 },
+    limit: 1
+  });
+
+  if (!media || media.length === 0) return {};
+  const primaryImage = media[0];
+
+  if (!primaryImage) return {};
+
+  return ensureAbsoluteUrls({
+    large: `${primaryImage.url({ store: "large" })}`,
+    medium: `${primaryImage.url({ store: "medium" })}`,
+    original: `${primaryImage.url({ store: "image" })}`,
+    small: `${primaryImage.url({ store: "small" })}`,
+    thumbnail: `${primaryImage.url({ store: "thumbnail" })}`
+  }, context);
+}

--- a/src/xforms/xformOrderItems.js
+++ b/src/xforms/xformOrderItems.js
@@ -6,9 +6,9 @@ import imageURLs from "../util/imageURLs.js";
  * @returns {Object[]} Same array with GraphQL-only props added
  */
 export default async function xformOrderItems(context, items) {
-  const xformedItems = items.map((item) => ({
+  const xformedItems = Promise.all(items.map(async (item) => ({
     ...item,
-    imageURLs: imageURLs(context, item),
+    imageURLs: await imageURLs(context, item),
     productConfiguration: {
       productId: item.productId,
       productVariantId: item.variantId
@@ -17,7 +17,7 @@ export default async function xformOrderItems(context, items) {
       amount: item.subtotal,
       currencyCode: item.price.currencyCode
     }
-  }));
+  })));
 
   for (const mutateItems of context.getFunctionsOfType("xformOrderItems")) {
     await mutateItems(context, xformedItems); // eslint-disable-line no-await-in-loop

--- a/src/xforms/xformOrderItems.js
+++ b/src/xforms/xformOrderItems.js
@@ -1,3 +1,5 @@
+import imageURLs from "../util/imageURLs.js";
+
 /**
  * @param {Object} context - an object containing the per-request state
  * @param {Object[]} items Array of order fulfillment group items
@@ -6,6 +8,7 @@
 export default async function xformOrderItems(context, items) {
   const xformedItems = items.map((item) => ({
     ...item,
+    imageURLs: imageURLs(context, item),
     productConfiguration: {
       productId: item.productId,
       productVariantId: item.variantId


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
The image URLs for order items are not being fetched and are not served in the request payload. The same bug was present in the `carts` plugin and was fixed by this PR https://github.com/reactioncommerce/api-plugin-carts/commit/7c2a153572b1dbcefc5faf0ed9a9c65a46b9ed45

## Solution
As the order item images are needed in the email templates, for example, they need to be added in the `xformOrderItems`.

## Testing
Response before the fix:
```
"items": {
  "nodes": [
    {
      "title": "Primary 1 Product",
      "imageURLs": null
    }
  ]
}
```

Response after the fix:
```
"items": {
  "nodes": [
    {
      "title": "Primary 1 Product",
      "imageURLs": {
        "large": "http://localhost:3000/assets/files/Media/BknHFoW8sypPdGXyB/large/banner.jpg",
        "medium": "http://localhost:3000/assets/files/Media/BknHFoW8sypPdGXyB/medium/banner.jpg",
        "original": "http://localhost:3000/assets/files/Media/BknHFoW8sypPdGXyB/image/banner.jpg",
        "small": "http://localhost:3000/assets/files/Media/BknHFoW8sypPdGXyB/small/banner.png",
        "thumbnail": "http://localhost:3000/assets/files/Media/BknHFoW8sypPdGXyB/thumbnail/banner.png"
      }
    }
  ]
}
```